### PR TITLE
Add ability to append extra text to pull request description

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -270,3 +270,7 @@ func (f fakeSystemsConfig) GitEmail() string {
 func (f fakeSystemsConfig) GetSlackToken() string {
 	return ""
 }
+
+func (f fakeSystemsConfig) PullRequestBodyExtra() string {
+	return ""
+}

--- a/config/system.go
+++ b/config/system.go
@@ -65,6 +65,9 @@ type SystemConfig interface {
 	GitEmail() string
 
 	GetSlackToken() string
+
+	// PullRequestBodyExtra returns a string to append to an automatically created pull request.
+	PullRequestBodyExtra() string
 }
 
 // NewSystemConfig creates a new instance of system config.
@@ -146,6 +149,8 @@ type envVarSysConfig struct {
 
 	// SlackToken is a slack API token
 	SlackToken string `env:"SLACK_TOKEN"`
+
+	PRBodyExtra string `env:"PR_BODY_TEMPLATE"`
 }
 
 func (e envVarSysConfig) GetSlackToken() string {
@@ -271,4 +276,9 @@ func (e envVarSysConfig) GitUser() string {
 // GitEmail returns a git email.
 func (e envVarSysConfig) GitEmail() string {
 	return "watchdog[bot]@users.noreply." + e.GithubBaseURL
+}
+
+// PullRequestBodyExtra returns an extra string to append to automated PRs.
+func (e envVarSysConfig) PullRequestBodyExtra() string {
+	return e.PRBodyExtra
 }

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -134,7 +134,7 @@ func (c *Controller) CreatePullRequest(team, project, configFile string, compone
 		return nil
 	}
 
-	pullRequestTitle, pullRequestBody := c.preparePullRequestDescription(team, patch, configFile, componentsMap)
+	pullRequestTitle, pullRequestBody := c.preparePullRequestDescription(team, patch, configFile, c.cfg.PullRequestBodyExtra(), componentsMap)
 
 	logrus.Infof("A change has been detected. Patch:\n%s", patch)
 
@@ -223,7 +223,7 @@ func (c *Controller) tryCloseOutdatedPRs(newPRNumber int, prs []*github.PullRequ
 	}
 }
 
-func (c *Controller) preparePullRequestDescription(team, patch, configFile string, componentsMap map[types.Component][]int) (title, body string) {
+func (c *Controller) preparePullRequestDescription(team, patch, configFile, bodyExtra string, componentsMap map[types.Component][]int) (title, body string) {
 	title = fmt.Sprintf("[Automated PR] Update datadog component files owned by [%s] - %s", team, configFile)
 
 	body = "Modified component files have been detected and a new PR has been created\n\n"
@@ -239,6 +239,11 @@ func (c *Controller) preparePullRequestDescription(team, patch, configFile strin
 				body += ":warning: **Closing this PR will revert all changes made in datadog!!!**"
 			}
 		}
+	}
+
+	if bodyExtra != "" {
+		body += "\n\n"
+		body += bodyExtra
 	}
 
 	return

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -1,0 +1,46 @@
+package controller
+
+import (
+	"github.com/coinbase/watchdog/primitives/datadog/types"
+	"testing"
+)
+
+func TestController_preparePullRequestDescription(t *testing.T) {
+	c := &Controller{}
+
+	components := map[types.Component][]int{
+		types.ComponentDashboard: {1, 2, 3},
+	}
+
+	title, body := c.preparePullRequestDescription("test-team", "patch-string", "test/file1.yml", "bodyExtra", components)
+
+	expectedTitle := "[Automated PR] Update datadog component files owned by [test-team] - test/file1.yml"
+	expectedBody := "Modified component files have been detected and a new PR has been created\n\n"
+	expectedBody += "The following components are different from master branch:\npatch-string\n\n"
+	expectedBody += "\n\nbodyExtra"
+
+	if title != expectedTitle {
+		t.Fatalf("expect title %s .Got %s", expectedTitle, title)
+	}
+
+	if body != expectedBody {
+		t.Fatalf("expect body %s .Got %s", expectedBody, body)
+	}
+
+	components = map[types.Component][]int{
+		types.ComponentDashboard: {1},
+	}
+	title, body = c.preparePullRequestDescription("test-team", "patch-string", "test/file1.yml", "", components)
+	expectedTitle = "[Automated PR] Update datadog component files owned by [test-team] - test/file1.yml dashboard 1"
+	expectedBody = "Modified component files have been detected and a new PR has been created\n\n"
+	expectedBody += "The following components are different from master branch:\npatch-string\n\n"
+	expectedBody += ":warning: **Closing this PR will revert all changes made in datadog!!!**"
+
+	if title != expectedTitle {
+		t.Fatalf("expect title %s .Got %s", expectedTitle, title)
+	}
+
+	if body != expectedBody {
+		t.Fatalf("expect body %s .Got %s", expectedBody, body)
+	}
+}

--- a/controller/mocks_test.go
+++ b/controller/mocks_test.go
@@ -227,3 +227,7 @@ func (f fakeSystemsConfig) GitEmail() string {
 func (f fakeSystemsConfig) GetSlackToken() string {
 	return ""
 }
+
+func (f fakeSystemsConfig) PullRequestBodyExtra() string {
+	return ""
+}


### PR DESCRIPTION
## What?

Adds a new method to system config interface. The new method returns a string which is appended to every automatically created PR.

## Why?

We may want to include extra information in PR

## Test Plan

Added new unittests