### PR TITLE
Fix github api url when using default

### DIFF
--- a/config/system.go
+++ b/config/system.go
@@ -262,7 +262,7 @@ func (e envVarSysConfig) GithubAppPrivateKeyBytes() []byte {
 // GithubAPIURL return a URL to github API.
 func (e envVarSysConfig) GithubAPIURL() string {
 	if e.GithubBaseURL == defaultGithubBaseURL {
-		return defaultGithubAPIBaseURL
+		return fmt.Sprintf("https://%s", e.GithubBaseURL)
 	}
 
 	return fmt.Sprintf("https://%s/api/v3", e.GithubBaseURL)

--- a/config/system.go
+++ b/config/system.go
@@ -262,7 +262,7 @@ func (e envVarSysConfig) GithubAppPrivateKeyBytes() []byte {
 // GithubAPIURL return a URL to github API.
 func (e envVarSysConfig) GithubAPIURL() string {
 	if e.GithubBaseURL == defaultGithubBaseURL {
-		return fmt.Sprintf("https://%s", e.GithubBaseURL)
+		return fmt.Sprintf("https://%s", defaultGithubAPIBaseURL)
 	}
 
 	return fmt.Sprintf("https://%s/api/v3", e.GithubBaseURL)


### PR DESCRIPTION
The Github API url when not using a custom subdomain is just `https://api.github.com` without the `/api/v3`. (https://developer.github.com/v3/)
The current code also misses the `https://` in the default case.
This fixes issue #9 , tested locally.